### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ siVAE requires installation of siVAE package as well as modified deepexplain fro
 Install siVAE by running the following command on the package file.
 
 ```
-pip install -e siVAE
+pip install siVAE
 ```
 
 The package requires tensorflow >= 1.15 and tensorflow probability. In addition, installation of tensorflow-gpu is recommended for faster performance.


### PR DESCRIPTION
changing "pip install -e siVAE" for "pip install siVAE". According to man pip, "-e" flag is used to specify a local path or a URL.